### PR TITLE
Derive secondary color from other colors

### DIFF
--- a/handlers/cbquery.js
+++ b/handlers/cbquery.js
@@ -20,7 +20,7 @@ async function saveColorToTheme(ctx, theme, themeId, color) {
 
     if (length < 3) {
         await ctx.editMessageCaption(
-            ctx.i18n(`choose_color_${length + (length === 2 ? 2 : 1)}`, {
+            ctx.i18n(`choose_color_${length + 1}`, {
                 colors: theme.using.join(`, `),
             }),
             { reply_markup: keyboard },

--- a/handlers/cbquery.js
+++ b/handlers/cbquery.js
@@ -18,9 +18,9 @@ async function saveColorToTheme(ctx, theme, themeId, color) {
     const keyboard = ctx.keyboard(true);
     const { length } = theme.using;
 
-    if (length < 4) {
+    if (length < 3) {
         await ctx.editMessageCaption(
-            ctx.i18n(`choose_color_${length + 1}`, {
+            ctx.i18n(`choose_color_${length + (length === 2 ? 2 : 1)}`, {
                 colors: theme.using.join(`, `),
             }),
             { reply_markup: keyboard },
@@ -134,7 +134,7 @@ module.exports = bot => {
             case `attheme`: {
                 const typing = ctx.action(`upload_photo`);
                 const { photo, using } = theme;
-                const name = ctx.makeThemeName(using[0], using[3]);
+                const name = ctx.makeThemeName(using[0], using[2]);
 
                 const completedTheme = ctx.makeTheme({
                     type: data,

--- a/variables/helpers.js
+++ b/variables/helpers.js
@@ -4,7 +4,8 @@ const isLight = c => Color(c).isLight();
 
 /**
  * Changes to brightness of a color.
- * @param {number} ratio A number between -100 and 100 (if it is negative, `color` will be darkened)
+ * @param {number} ratio A number between -100 and 100
+ * (if it is negative, `color` will be darkened)
  * @param {boolean} [invert] if true, ratio is negated.
  * @returns {string} A color with lightness of `color.lightness() + ratio`
  */
@@ -17,8 +18,9 @@ function adjustBrightness(color, ratio, invert = false) {
 
 const getFgColor = bg => isLight(bg) ? adjustBrightness(bg, -45) : `#ffffff`;
 
-function themeData([filling, text, secondaryText, primary]) {
-    const themeIsLight = isLight(filling),
+function themeData([filling, text,, primary]) {
+    const secondaryText = Color(filling).mix(Color(text)).hex(),
+        themeIsLight = isLight(filling),
         textOnPrimary = getFgColor(primary),
         background = adjustBrightness(filling, -6.5),
         backgroundText = adjustBrightness(secondaryText, 5, themeIsLight),
@@ -27,13 +29,11 @@ function themeData([filling, text, secondaryText, primary]) {
             themeIsLight ? 41 : -3,
         );
 
-    // const st = Color(filling).mix(Color(text)).hex();
     return {
         background,
         filling,
         text,
         backgroundText,
-        // secondaryText: st,
         secondaryText,
         primary,
         textOnPrimary,

--- a/variables/helpers.js
+++ b/variables/helpers.js
@@ -19,11 +19,11 @@ function adjustBrightness(color, ratio, invert = false) {
 const getFgColor = bg => isLight(bg) ? adjustBrightness(bg, -45) : `#ffffff`;
 
 function themeData([filling, text, primary]) {
-    const secondaryText = Color(filling).mix(Color(text)).hex(),
-        themeIsLight = isLight(filling),
+    const themeIsLight = isLight(filling),
         textOnPrimary = getFgColor(primary),
         background = adjustBrightness(filling, -6.5),
-        backgroundText = adjustBrightness(secondaryText, 5, themeIsLight),
+        secondaryText = Color(filling).mix(Color(text), .4).hex(),
+        backgroundText = adjustBrightness(secondaryText, -10, themeIsLight),
         bubbleOutColor = adjustBrightness(
             themeIsLight ? primary : filling,
             themeIsLight ? 41 : -3,

--- a/variables/helpers.js
+++ b/variables/helpers.js
@@ -18,7 +18,7 @@ function adjustBrightness(color, ratio, invert = false) {
 
 const getFgColor = bg => isLight(bg) ? adjustBrightness(bg, -45) : `#ffffff`;
 
-function themeData([filling, text,, primary]) {
+function themeData([filling, text, primary]) {
     const secondaryText = Color(filling).mix(Color(text)).hex(),
         themeIsLight = isLight(filling),
         textOnPrimary = getFgColor(primary),

--- a/variables/tgx-theme.js
+++ b/variables/tgx-theme.js
@@ -38,57 +38,61 @@ module.exports = (name, colors) => {
 
         headerBackground: ${headerBackground}
         headerLightBackground: ${themeIsLight ? filling : headerBackground}
-        headerText, headerIcon: ${headerText}
+        headerText, headerIcon, chatListAction: ${headerText}
         headerLightIcon, headerLightText: ${themeIsLight ? text : headerText}
         headerTabActiveText, headerTabActive: ${headerTabColor}
         headerButton: ${themeIsLight ? filling : primary}
-        headerButtonIcon: ${themeIsLight ? secondaryText : textOnPrimary}
+        headerButtonIcon, circleButtonRegularIcon, circleButtonThemeIcon: ${themeIsLight ? secondaryText : textOnPrimary}
 
-        iconActive, progress, controlActive, checkActive, sliderActive, togglerActive, inputActive, inlineIcon, inlineOutline, bubbleOut_inlineOutline, inlineText, bubbleOut_inlineText, bubbleOut_inlineIcon, ticks, ticksRead, bubbleOut_ticks, bubbleOut_ticksRead, bubbleOut_file, file, bubbleOut_waveformActive, waveformActive, bubbleIn_textLink, bubbleOut_textLink, textLink, chatSendButton, textSearchQueryHighlight, profileSectionActive, profileSectionActiveContent, badge, bubbleOut_chatVerticalLine, messageVerticalLine, bubbleOut_messageAuthor, messageAuthor, messageSwipeBackground, unreadText, bubble_unreadText, bubble_unreadText_noWallpaper, textNeutral, seekDone, promo, online, playerButtonActive, chatListVerify, fillingPositive, passcode, notification, notificationSecure, notificationPlayer, headerBarCallActive, fileAttach: ${primary}
+        iconActive, progress, controlActive, checkActive, sliderActive, togglerActive, inputActive, inlineIcon, inlineOutline, bubbleOut_inlineOutline, inlineText, bubbleOut_inlineText, bubbleOut_inlineIcon, ticks, ticksRead, bubbleOut_ticks, bubbleOut_ticksRead, bubbleOut_file, file, bubbleOut_waveformActive, waveformActive, bubbleIn_textLink, bubbleOut_textLink, textLink, chatSendButton, textSearchQueryHighlight, profileSectionActive, profileSectionActiveContent, badge, bubbleOut_chatVerticalLine, messageVerticalLine, bubbleOut_messageAuthor, messageAuthor, messageSwipeBackground, unreadText, bubble_unreadText, bubble_unreadText_noWallpaper, textNeutral, seekDone, promo, online, playerButtonActive, chatListVerify, fillingPositive, notification, notificationSecure, notificationPlayer, headerBarCallActive, fileAttach: ${primary}
 
-        messageSwipeContent, passcodeIcon, passcodeText, fillingPositiveContent, attachText, chatListAction: ${textOnPrimary}
+        messageSwipeContent, fillingPositiveContent: ${textOnPrimary}
+        
+        passcode: ${headerBackground}
+        passcodeIcon, passcodeText: ${headerText}
 
-
-        circleButtonRegular, circleButtonTheme: ${primary}
-        circleButtonNewSecret, fileGreen: ${adjustBrightness(primary, 3)}
-        circleButtonNewChannel, fileYellow: ${adjustBrightness(primary, 5.5)}
-        circleButtonNewGroup: ${adjustBrightness(primary, 12)}
-        circleButtonNewChat, fileRed: ${adjustBrightness(primary, 6.3)}
+        circleButtonRegular, circleButtonTheme, circleButtonNewGroup, circleButtonNewSecret,  circleButtonNewChannel, circleButtonNewChat: ${primary}
+        circleButtonNewGroupIcon, circleButtonNewSecretIcon,  circleButtonNewChannelIcon, circleButtonNewChatIcon: ${textOnPrimary}
+        fileGreen: ${adjustBrightness(primary, 3)}
+        fileYellow: ${adjustBrightness(primary, 5.5)}
+        fileRed: ${adjustBrightness(primary, 6.3)}
         circleButtonChat, circleButtonOverlay: ${filling}
         circleButtonChatIcon, circleButtonOverlayIcon, bubbleIn_time, bubbleOut_time, bubbleOut_progress, textPlaceholder, controlInactive: ${secondaryText}
 
         headerRemoveBackgroundHighlight, introSectionActive, playerButton, text: ${text}
 
-        avatarCyan, nameCyan, attachContact: ${adjustBrightness(
+        attachContact, attachFile, attachPhoto, attachLocation, attachInlineBot: ${headerBackground}
+        attachText: ${headerText}
+        avatarCyan, nameCyan: ${adjustBrightness(
             primary,
-            17,
+            8,
             themeIsLight,
         )}
         avatarBlue, nameBlue: ${adjustBrightness(primary, themeIsLight, 15)}
-        avatarGreen, nameGreen, attachFile: ${adjustBrightness(
+        avatarGreen, nameGreen: ${adjustBrightness(
             primary,
-            10,
+            4,
             themeIsLight,
         )}
         avatarViolet, nameViolet: ${adjustBrightness(primary, 5, themeIsLight)}
-        avatarRed, nameRed, attachPhoto: ${adjustBrightness(
+        avatarRed, nameRed: ${adjustBrightness(
+            primary,
+            -2,
+            themeIsLight,
+        )}
+        avatarPink, namePink: ${adjustBrightness(
             primary,
             -5,
             themeIsLight,
         )}
-        avatarPink, namePink, attachLocation: ${adjustBrightness(
+        avatarYellow, nameYellow: ${adjustBrightness(
             primary,
-            -10,
-            themeIsLight,
-        )}
-        avatarYellow, nameYellow, attachInlineBot: ${adjustBrightness(
-            primary,
-            -15,
+            -9,
             themeIsLight,
         )}
         avatarOrange, nameOrange: ${adjustBrightness(
             primary,
-            -17,
+            -12,
             themeIsLight,
         )}
         avatarSavedMessages: ${primary}
@@ -108,7 +112,7 @@ module.exports = (name, colors) => {
         bubbleOut_waveformInactive, waveformInactive: ${secondaryText}74
         bubbleOut_text, bubbleIn_text: ${text}
         seekEmpty, seekReady, playerCoverPlaceholder: ${text}19
-        headerTabInactiveText: ${textOnPrimary}97
+        headerTabInactiveText: ${headerText}97
         togglerActiveBackground: ${primary}97
         unread, bubble_unread, bubble_unread_noWallpaper: ${primary}18
         previewBackground: ${filling}C0


### PR DESCRIPTION
As we discussed, the secondary color is no longer prompted from the user; and the bot now prompts 4 colors instead of 3. Changes are tested on the TGX template, and I think no bug is expected for the other templates. :thinking: 
> I did [something bad](https://github.com/hkh12/ThemerBot/blob/921ea660c0e6cd6a1991487385c51bc25b99d5f3/handlers/cbquery.js#L23). Translations for secondary color (`choose_color_3`) should be removed.