### PR TITLE
Switch the image file separators to support Windows

### DIFF
--- a/middleware/storage.js
+++ b/middleware/storage.js
@@ -24,7 +24,7 @@ client.on(`error`, error => {
 const get = promisify(client.get).bind(client);
 const set = promisify(client.set).bind(client);
 const del = promisify(client.del).bind(client);
-const getKey = (ctx, messageId) => `themerbot-${ctx.chat.id}-${ctx.from.id}-${messageId}`;
+const getKey = (ctx, messageId) => `themerbot_${ctx.chat.id}_${ctx.from.id}_${messageId}`;
 
 module.exports = bot => {
     bot.context.saveTheme = async function (messageId, theme) {

--- a/middleware/storage.js
+++ b/middleware/storage.js
@@ -24,7 +24,7 @@ client.on(`error`, error => {
 const get = promisify(client.get).bind(client);
 const set = promisify(client.set).bind(client);
 const del = promisify(client.del).bind(client);
-const getKey = (ctx, messageId) => `themerbot:${ctx.chat.id}:${ctx.from.id}:${messageId}`;
+const getKey = (ctx, messageId) => `themerbot-${ctx.chat.id}-${ctx.from.id}-${messageId}`;
 
 module.exports = bot => {
     bot.context.saveTheme = async function (messageId, theme) {


### PR DESCRIPTION
Allows users to run on Windows as colons ":" are not valid characters in file names.